### PR TITLE
feat/rebuild backup a saurus

### DIFF
--- a/.github/workflows/rebuild-backupasaurus.yml
+++ b/.github/workflows/rebuild-backupasaurus.yml
@@ -38,6 +38,6 @@ jobs:
       - name: circleci workflow
         id: circleci
         run: |
-          curl --location --request POST 'https://circleci.com/api/v2/project/github/springload/backup-a-saurus/pipeline' \
-          --header 'Content-Type: application/json' \
+          curl 'https://circleci.com/api/v1.1/project/github/springload/backup-a-saurus/tree/master' \
+          -d 'build_parameters[CIRCLE_JOB]=build' \
           -u "${API_TOKEN}:"

--- a/.github/workflows/rebuild-backupasaurus.yml
+++ b/.github/workflows/rebuild-backupasaurus.yml
@@ -1,0 +1,43 @@
+name: Backup-a-saurus
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      gpg_modified: ${{ steps.modified_dirs.outputs.gpg_modified }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: check modified directories
+        id: modified_dirs
+        run: |
+          CMD="git diff --name-only HEAD^ HEAD"
+          echo "Modified files:"
+          $CMD
+
+          # Check if gpg dir has been modified
+          MODIFIED=$($CMD gpg)
+          if [[ -n "${MODIFIED}" ]]; then
+            echo "Trigger docker build"
+            echo "::set-output name=gpg_modified::true"
+          else
+            echo "::set-output name=gpg_modified::false"
+          fi
+
+  trigger-rebuild:
+    runs-on: ubuntu-latest
+    needs: check-gpg-changed
+    if: github.event.pull_request.merged == true && needs.check.outputs.gpg_modified == true
+    env:
+      API_TOKEN: ${{ secrets.CIRCLECI_API_TOKEN }}
+    steps:
+      - name: circleci workflow
+        id: circleci
+        run: |
+          curl --location --request POST 'https://circleci.com/api/v2/project/github/springload/backup-a-saurus/pipeline' \
+          --header 'Content-Type: application/json' \
+          -u "${API_TOKEN}:"


### PR DESCRIPTION
If this works, then when a user adds/modifies/removes their GPG key, it should re-trigger a build of the backup-a-saurus docker image.

To test this, I created a token that I saved locally and ran the `curl` command referenced in the rebuild step.
A new `build` workflow was triggered: https://app.circleci.com/pipelines/github/springload/backup-a-saurus/25/workflows/078a0b1c-ba09-4ac1-92fa-88ff4e804a48

Additional tasks:
- get a circleci "admin" [api token](https://app.circleci.com/settings/project/github/springload/backup-a-saurus/api) and add it to this repo's secrets as `CIRCLECI_API_TOKEN`
  - Done ✅ 

Resources:
- https://circleci.com/docs/2.0/triggers/
- https://support.circleci.com/hc/en-us/articles/360047039292-Step-that-triggers-pipeline-in-different-project
